### PR TITLE
Fix stable Unix release staging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -312,7 +312,7 @@ jobs:
         run: |
           mkdir -p staging/${{ matrix.rid }}
           cp src/Ai.Tlbx.MidTerm/bin/Release/net10.0/${{ matrix.rid }}/publish/mt${{ matrix.ext }} staging/${{ matrix.rid }}/
-          cp version.json staging/${{ matrix.rid }}/
+          cp src/version.json staging/${{ matrix.rid }}/
 
           if [[ "${{ needs.prepare.outputs.is_web_only }}" != "true" ]]; then
             cp src/Ai.Tlbx.MidTerm.TtyHost/bin/Release/net10.0/${{ matrix.rid }}/publish/mthost${{ matrix.ext }} staging/${{ matrix.rid }}/

--- a/src/npx-launcher/package.json
+++ b/src/npx-launcher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tlbx-ai/midterm",
-  "version": "8.6.10",
+  "version": "8.6.11-dev",
   "description": "Launch MidTerm via npx by downloading the native binary for your platform",
   "license": "AGPL-3.0-only",
   "repository": {

--- a/src/version.json
+++ b/src/version.json
@@ -1,5 +1,5 @@
 {
-  "web": "8.6.10",
+  "web": "8.6.11-dev",
   "pty": "8.3.24",
   "protocol": 1,
   "minCompatiblePty": "2.0.0",


### PR DESCRIPTION
## Summary
Promoting `8.6.11-dev` to stable `8.6.11` - includes 1 dev releases since v8.6.10.

## Changelog

### v8.6.11-dev - Fix stable Unix release staging
- Fixed the stable Unix release workflow to stage src/version.json instead of the removed repo-root version.json after the repo restructure.
- Restored macOS and Linux stable packaging so public installers can resolve the correct release assets instead of failing during Stage artifacts.
