### PR TITLE
Installer certificate trust

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -293,7 +293,7 @@ The root `install.ps1` and `install.sh` scripts handle:
 
 - service mode versus user mode decisions
 - password setup, preservation, and intentional replacement during reinstall
-- certificate reuse or trust flows
+- certificate reuse plus trust flows for both newly generated and reused certificates
 - platform-specific install paths and service registration
 - channel selection and release download
 - update logging

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -33,7 +33,7 @@ This is the canonical feature sweep for the current codebase. The coverage order
 - `F010` The installers prompt for a required password on first install.
 - `F011` Installer updates preserve an existing password by default and allow setting a replacement password during reinstall.
 - `F012` Installers can reuse an existing valid local certificate.
-- `F013` Installers can trust the generated local certificate on the machine.
+- `F013` Installers can trust the current local certificate on the machine, including reused certificates during reinstall.
 - `F014` Installers log their actions to `update.log` in the mode-specific log location.
 - `F015` Installers detect the current OS and architecture and fetch the matching release asset.
 - `F016` Installers support stable and dev release channels.

--- a/install.sh
+++ b/install.sh
@@ -1168,15 +1168,36 @@ execute_certificate_trust() {
     fi
 
     if [ "$(uname -s)" = "Darwin" ]; then
+        local existing_hashes current_hash
+        existing_hashes=$(security find-certificate -a -Z -c ai.tlbx.midterm /Library/Keychains/System.keychain 2>/dev/null | \
+            sed -n 's/^SHA-256 hash: //p')
+        current_hash=$(openssl x509 -in "$cert_path" -noout -fingerprint -sha256 2>/dev/null | \
+            cut -d= -f2 | tr -d ':')
+
+        if [ -n "$existing_hashes" ]; then
+            while IFS= read -r cert_hash; do
+                [ -z "$cert_hash" ] && continue
+                if [ -n "$current_hash" ] && [ "$cert_hash" = "$current_hash" ]; then
+                    continue
+                fi
+                security delete-certificate -Z "$cert_hash" -t /Library/Keychains/System.keychain >/dev/null 2>&1 || true
+            done <<< "$existing_hashes"
+        fi
+
         local output exit_code
+        set +e
         output=$(security add-trusted-cert -d -r trustRoot \
             -k /Library/Keychains/System.keychain "$cert_path" 2>&1)
         exit_code=$?
+        set -e
         if [ $exit_code -eq 0 ]; then
             print_step "Trusting certificate..." "done"
         else
             print_step "Trusting certificate..." "manual trust needed" "$YELLOW"
             log "Could not auto-trust certificate (code: $exit_code): $output"
+            if [ -n "$current_hash" ]; then
+                log "Current certificate SHA-256: $current_hash"
+            fi
         fi
     else
         if cp "$cert_path" /usr/local/share/ca-certificates/midterm.crt 2>/dev/null && \
@@ -1200,9 +1221,11 @@ prompt_certificate_trust() {
     if [[ "$trust_choice" != "n" && "$trust_choice" != "N" ]]; then
         if [ "$(uname -s)" = "Darwin" ]; then
             local output exit_code
+            set +e
             output=$(sudo security add-trusted-cert -d -r trustRoot \
                 -k /Library/Keychains/System.keychain "$cert_path" 2>&1)
             exit_code=$?
+            set -e
             if [ $exit_code -eq 0 ]; then
                 print_step "Trusting certificate..." "done"
             else
@@ -1507,6 +1530,7 @@ install_as_service() {
     if check_existing_certificate "$existing_cert"; then
         log "Existing certificate is valid, reusing"
         CERT_PATH="$existing_cert"
+        execute_certificate_trust "$CERT_PATH"
     elif ! generate_certificate "$install_dir" "$settings_dir" true; then
         log "Certificate generation failed - app will use fallback" "WARN"
         print_step "Certificate..." "fallback (generation failed)" "$YELLOW"
@@ -2004,6 +2028,7 @@ install_as_user() {
     if check_existing_certificate "$existing_cert"; then
         log "Existing certificate is valid, reusing"
         CERT_PATH="$existing_cert"
+        prompt_certificate_trust "$CERT_PATH"
     elif ! generate_certificate "$install_dir" "$settings_dir" false; then
         log "Certificate generation failed - app will use fallback" "WARN"
         print_step "Certificate..." "fallback (generation failed)" "$YELLOW"

--- a/src/npx-launcher/package.json
+++ b/src/npx-launcher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tlbx-ai/midterm",
-  "version": "8.6.12",
+  "version": "8.6.13-dev",
   "description": "Launch MidTerm via npx by downloading the native binary for your platform",
   "license": "AGPL-3.0-only",
   "repository": {

--- a/src/version.json
+++ b/src/version.json
@@ -1,5 +1,5 @@
 {
-  "web": "8.6.12",
+  "web": "8.6.13-dev",
   "pty": "8.3.24",
   "protocol": 1,
   "minCompatiblePty": "2.0.0",


### PR DESCRIPTION
## Summary
Promoting `8.6.13-dev` to stable `8.6.13` - includes 1 dev releases since v8.6.12.

## Changelog

### v8.6.13-dev - Installer certificate trust
- Fixed the Unix installer so certificate trust is applied to reused certificates during reinstall instead of only newly generated certificates.
- Stopped macOS certificate trust failures from aborting the installer and kept the fallback at manual trust when trust cannot be completed non-interactively.
