### PR TITLE
Build TtyHost before CI release tests

### DIFF
--- a/src/Ai.Tlbx.MidTerm.Tests/Ai.Tlbx.MidTerm.Tests.csproj
+++ b/src/Ai.Tlbx.MidTerm.Tests/Ai.Tlbx.MidTerm.Tests.csproj
@@ -21,6 +21,8 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Ai.Tlbx.MidTerm\Ai.Tlbx.MidTerm.csproj" />
+    <ProjectReference Include="..\Ai.Tlbx.MidTerm.TtyHost\Ai.Tlbx.MidTerm.TtyHost.csproj"
+                      ReferenceOutputAssembly="false" />
   </ItemGroup>
 
 </Project>

--- a/src/Ai.Tlbx.MidTerm.Tests/TtyHostIntegrationTests.cs
+++ b/src/Ai.Tlbx.MidTerm.Tests/TtyHostIntegrationTests.cs
@@ -43,10 +43,21 @@ public class TtyHostIntegrationTests
 
     private static string FindTtyHostExe()
     {
+        var projectRoot = Path.GetFullPath(Path.Combine(
+            AppContext.BaseDirectory,
+            "..",
+            "..",
+            "..",
+            "..",
+            "Ai.Tlbx.MidTerm.TtyHost"));
+        var preferredConfiguration = IsReleaseTestRun() ? "Release" : "Debug";
+        var fallbackConfiguration = preferredConfiguration == "Release" ? "Debug" : "Release";
         var candidates = new[]
         {
-            Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", "Ai.Tlbx.MidTerm.TtyHost", "bin", "Debug", "net10.0", "win-x64", "mthost.exe"),
-            Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", "Ai.Tlbx.MidTerm.TtyHost", "bin", "Release", "net10.0", "win-x64", "mthost.exe"),
+            Path.Combine(projectRoot, "bin", preferredConfiguration, "net10.0", "win-x64", "mthost.exe"),
+            Path.Combine(projectRoot, "bin", preferredConfiguration, "net10.0", "mthost.exe"),
+            Path.Combine(projectRoot, "bin", fallbackConfiguration, "net10.0", "win-x64", "mthost.exe"),
+            Path.Combine(projectRoot, "bin", fallbackConfiguration, "net10.0", "mthost.exe"),
             @"C:\Program Files\MidTerm\mthost.exe",
         };
 
@@ -60,5 +71,12 @@ public class TtyHostIntegrationTests
         }
 
         return Path.GetFullPath(candidates[0]);
+    }
+
+    private static bool IsReleaseTestRun()
+    {
+        return AppContext.BaseDirectory.Contains(
+            $"{Path.DirectorySeparatorChar}Release{Path.DirectorySeparatorChar}",
+            StringComparison.OrdinalIgnoreCase);
     }
 }

--- a/src/npx-launcher/package.json
+++ b/src/npx-launcher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tlbx-ai/midterm",
-  "version": "9.6.1",
+  "version": "9.6.2-dev",
   "description": "Launch MidTerm via npx by downloading the native binary for your platform",
   "license": "AGPL-3.0-only",
   "repository": {

--- a/src/version.json
+++ b/src/version.json
@@ -1,5 +1,5 @@
 {
-  "web": "9.6.1",
+  "web": "9.6.2-dev",
   "pty": "9.4.51",
   "protocol": 1,
   "minCompatiblePty": "2.0.0",


### PR DESCRIPTION
## Summary
Promoting `9.6.2-dev` to stable `9.6.2` - includes 1 dev releases since v9.6.1.

## Changelog

### v9.6.2-dev - Build TtyHost before CI release tests
- Built Ai.Tlbx.MidTerm.TtyHost as an explicit dependency of Ai.Tlbx.MidTerm.Tests so the release test suite no longer checks for mthost.exe before the host project has been built.
- Made TtyHostIntegrationTests prefer the active test configuration and probe both RID and non-RID output paths before falling back to installed mthost locations.
- Fixed the stable release CI failure where the dotnet-tests job on windows-latest stopped at TtyHostExe_Exists even though the rest of the release workflow was healthy.

