### PR TITLE
Restore AgentHost before unit-test CI builds

### DIFF
--- a/src/Ai.Tlbx.MidTerm.UnitTests/Ai.Tlbx.MidTerm.UnitTests.csproj
+++ b/src/Ai.Tlbx.MidTerm.UnitTests/Ai.Tlbx.MidTerm.UnitTests.csproj
@@ -20,6 +20,8 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Ai.Tlbx.MidTerm\Ai.Tlbx.MidTerm.csproj" />
+    <ProjectReference Include="..\Ai.Tlbx.MidTerm.AgentHost\Ai.Tlbx.MidTerm.AgentHost.csproj"
+                      ReferenceOutputAssembly="false" />
     <ProjectReference Include="..\Ai.Tlbx.MidTerm.FakeCodex\Ai.Tlbx.MidTerm.FakeCodex.csproj" ReferenceOutputAssembly="false" />
     <ProjectReference Include="..\Ai.Tlbx.MidTerm.FakeClaude\Ai.Tlbx.MidTerm.FakeClaude.csproj" ReferenceOutputAssembly="false" />
   </ItemGroup>
@@ -39,11 +41,4 @@
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
-
-  <Target Name="BuildAgentHostForUnitTests" BeforeTargets="Build">
-    <MSBuild Projects="..\Ai.Tlbx.MidTerm.AgentHost\Ai.Tlbx.MidTerm.AgentHost.csproj"
-             Targets="Build"
-             Properties="Configuration=$(Configuration)" />
-  </Target>
-
 </Project>

--- a/src/npx-launcher/package.json
+++ b/src/npx-launcher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tlbx-ai/midterm",
-  "version": "9.6.2",
+  "version": "9.6.3-dev",
   "description": "Launch MidTerm via npx by downloading the native binary for your platform",
   "license": "AGPL-3.0-only",
   "repository": {

--- a/src/version.json
+++ b/src/version.json
@@ -1,5 +1,5 @@
 {
-  "web": "9.6.2",
+  "web": "9.6.3-dev",
   "pty": "9.4.51",
   "protocol": 1,
   "minCompatiblePty": "2.0.0",


### PR DESCRIPTION
## Summary
Promoting `9.6.3-dev` to stable `9.6.3` - includes 1 dev releases since v9.6.2.

## Changelog

### v9.6.3-dev - Restore AgentHost before unit-test CI builds
- Replaced the unit-test project's custom pre-build MSBuild call for Ai.Tlbx.MidTerm.AgentHost with a real project reference so restore and build ordering stay correct under CI.
- Fixed the stable release dotnet-tests failure where Ai.Tlbx.MidTerm.UnitTests hit NETSDK1004 because the AgentHost assets file had never been restored on windows-latest.
- Kept the AgentHost test path explicit so mtagenthost outputs are still built for unit tests without relying on a fragile extra build target.

