### PR TITLE
Make release tests configuration-aware

### DIFF
--- a/src/Ai.Tlbx.MidTerm.AgentHost.UnitTests/Ai.Tlbx.MidTerm.AgentHost.UnitTests.csproj
+++ b/src/Ai.Tlbx.MidTerm.AgentHost.UnitTests/Ai.Tlbx.MidTerm.AgentHost.UnitTests.csproj
@@ -38,6 +38,7 @@
     <Compile Include="..\Ai.Tlbx.MidTerm.UnitTests\MtAgentHostRealResumeCatalogSmokeTests.cs" Link="MtAgentHostRealResumeCatalogSmokeTests.cs" />
     <Compile Include="..\Ai.Tlbx.MidTerm.UnitTests\PathSensitiveEnvironmentCollection.cs" Link="PathSensitiveEnvironmentCollection.cs" />
     <Compile Include="..\Ai.Tlbx.MidTerm.UnitTests\SessionLensHistoryServiceTests.cs" Link="SessionLensHistoryServiceTests.cs" />
+    <Compile Include="..\Ai.Tlbx.MidTerm.UnitTests\TestExecutablePathResolver.cs" Link="TestExecutablePathResolver.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Ai.Tlbx.MidTerm.UnitTests/FakeClaudePathScope.cs
+++ b/src/Ai.Tlbx.MidTerm.UnitTests/FakeClaudePathScope.cs
@@ -31,13 +31,12 @@ internal sealed class FakeClaudePathScope : IDisposable
         var root = Path.Combine(Path.GetTempPath(), "midterm-fake-claude-" + Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(root);
 
-        var fakeClaudeBin = ResolveFakeClaudeOutputDirectory();
-        var executableName = OperatingSystem.IsWindows() ? "claude.exe" : "claude";
-        var executablePath = Path.Combine(fakeClaudeBin, executableName);
-        if (!File.Exists(executablePath))
-        {
-            throw new InvalidOperationException($"Expected fake Claude executable at '{executablePath}'.");
-        }
+        var executablePath = TestExecutablePathResolver.ResolveExecutablePath(
+            AppContext.BaseDirectory,
+            "Ai.Tlbx.MidTerm.FakeClaude",
+            "claude");
+        var fakeClaudeBin = Path.GetDirectoryName(executablePath)
+            ?? throw new InvalidOperationException($"Could not determine fake Claude output directory from '{executablePath}'.");
 
         var originalPath = Environment.GetEnvironmentVariable("PATH");
         var originalStateDir = Environment.GetEnvironmentVariable(FakeClaudeStateDirVariable);
@@ -59,17 +58,5 @@ internal sealed class FakeClaudePathScope : IDisposable
         catch
         {
         }
-    }
-
-    private static string ResolveFakeClaudeOutputDirectory()
-    {
-        var repoRoot = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", ".."));
-        return Path.Combine(
-            repoRoot,
-            "src",
-            "Ai.Tlbx.MidTerm.FakeClaude",
-            "bin",
-            "Debug",
-            "net10.0");
     }
 }

--- a/src/Ai.Tlbx.MidTerm.UnitTests/FakeCodexPathScope.cs
+++ b/src/Ai.Tlbx.MidTerm.UnitTests/FakeCodexPathScope.cs
@@ -28,13 +28,12 @@ internal sealed class FakeCodexPathScope : IDisposable
         var root = Path.Combine(Path.GetTempPath(), "midterm-fake-codex-" + Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(root);
 
-        var fakeCodexBin = ResolveFakeCodexOutputDirectory();
-        var executableName = OperatingSystem.IsWindows() ? "codex.exe" : "codex";
-        var executablePath = Path.Combine(fakeCodexBin, executableName);
-        if (!File.Exists(executablePath))
-        {
-            throw new InvalidOperationException($"Expected fake Codex executable at '{executablePath}'.");
-        }
+        var executablePath = TestExecutablePathResolver.ResolveExecutablePath(
+            AppContext.BaseDirectory,
+            "Ai.Tlbx.MidTerm.FakeCodex",
+            "codex");
+        var fakeCodexBin = Path.GetDirectoryName(executablePath)
+            ?? throw new InvalidOperationException($"Could not determine fake Codex output directory from '{executablePath}'.");
 
         var originalPath = Environment.GetEnvironmentVariable("PATH");
         var capturePath = Path.Combine(root, "fake-codex-launch.json");
@@ -55,17 +54,5 @@ internal sealed class FakeCodexPathScope : IDisposable
         catch
         {
         }
-    }
-
-    private static string ResolveFakeCodexOutputDirectory()
-    {
-        var repoRoot = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", ".."));
-        return Path.Combine(
-            repoRoot,
-            "src",
-            "Ai.Tlbx.MidTerm.FakeCodex",
-            "bin",
-            "Debug",
-            "net10.0");
     }
 }

--- a/src/Ai.Tlbx.MidTerm.UnitTests/LensHostEnvironmentResolverTests.cs
+++ b/src/Ai.Tlbx.MidTerm.UnitTests/LensHostEnvironmentResolverTests.cs
@@ -123,10 +123,23 @@ public sealed class LensHostEnvironmentResolverTests
             return;
         }
 
-        var profileDirectory = LensHostEnvironmentResolver.ResolveWindowsProfileDirectoryFromExecutablePath(
-            @"C:\Users\johan\AppData\Roaming\npm\codex.cmd");
+        var profileDirectory = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        var executablePath = Path.Combine(profileDirectory, "AppData", "Roaming", "npm", "codex.cmd");
+        Directory.CreateDirectory(Path.GetDirectoryName(executablePath)!);
 
-        Assert.Equal(Path.Combine("C:\\", "Users", "johan"), profileDirectory);
+        try
+        {
+            var resolved = LensHostEnvironmentResolver.ResolveWindowsProfileDirectoryFromExecutablePath(executablePath);
+
+            Assert.Equal(profileDirectory, resolved);
+        }
+        finally
+        {
+            if (File.Exists(executablePath))
+            {
+                File.Delete(executablePath);
+            }
+        }
     }
 
     [Fact]

--- a/src/Ai.Tlbx.MidTerm.UnitTests/TestExecutablePathResolver.cs
+++ b/src/Ai.Tlbx.MidTerm.UnitTests/TestExecutablePathResolver.cs
@@ -1,0 +1,34 @@
+namespace Ai.Tlbx.MidTerm.UnitTests;
+
+internal static class TestExecutablePathResolver
+{
+    public static string ResolveExecutablePath(string baseDirectory, string projectDirectoryName, string executableBaseName)
+    {
+        var repoRoot = Path.GetFullPath(Path.Combine(baseDirectory, "..", "..", "..", "..", ".."));
+        var executableName = OperatingSystem.IsWindows() ? executableBaseName + ".exe" : executableBaseName;
+        var preferredConfiguration = baseDirectory.Contains($"{Path.DirectorySeparatorChar}Release{Path.DirectorySeparatorChar}", StringComparison.OrdinalIgnoreCase)
+            ? "Release"
+            : baseDirectory.Contains($"{Path.DirectorySeparatorChar}Debug{Path.DirectorySeparatorChar}", StringComparison.OrdinalIgnoreCase)
+                ? "Debug"
+                : null;
+        var configurations = preferredConfiguration is null
+            ? new[] { "Debug", "Release" }
+            : new[] { preferredConfiguration, string.Equals(preferredConfiguration, "Release", StringComparison.Ordinal) ? "Debug" : "Release" };
+
+        foreach (var configuration in configurations)
+        {
+            var candidates = new[]
+            {
+                Path.Combine(repoRoot, "src", projectDirectoryName, "bin", configuration, "net10.0", "win-x64", executableName),
+                Path.Combine(repoRoot, "src", projectDirectoryName, "bin", configuration, "net10.0", executableName)
+            };
+            var resolved = candidates.FirstOrDefault(File.Exists);
+            if (!string.IsNullOrWhiteSpace(resolved))
+            {
+                return resolved;
+            }
+        }
+
+        throw new FileNotFoundException($"Could not resolve '{executableName}' build output for test project '{projectDirectoryName}'.");
+    }
+}

--- a/src/npx-launcher/package.json
+++ b/src/npx-launcher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tlbx-ai/midterm",
-  "version": "9.6.3",
+  "version": "9.6.4-dev",
   "description": "Launch MidTerm via npx by downloading the native binary for your platform",
   "license": "AGPL-3.0-only",
   "repository": {

--- a/src/version.json
+++ b/src/version.json
@@ -1,5 +1,5 @@
 {
-  "web": "9.6.3",
+  "web": "9.6.4-dev",
   "pty": "9.4.51",
   "protocol": 1,
   "minCompatiblePty": "2.0.0",


### PR DESCRIPTION
## Summary
Promoting `9.6.4-dev` to stable `9.6.4` - includes 1 dev releases since v9.6.3.

## Changelog

### v9.6.4-dev - Make release tests configuration-aware
- Made fake Codex and Claude test helpers resolve Release and Debug build outputs instead of assuming Debug-only executable paths.
- Stabilized the Windows profile resolver test by using the real current user profile rather than trying to create a synthetic C:\Users path on CI machines.
- Linked the shared executable-path helper into both unit-test projects so the stable release dotnet-tests job now builds and runs cleanly on windows-latest.

