### PR TITLE
Fix stable Windows signature verification script

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -632,7 +632,7 @@ jobs:
           foreach ($file in $files) {
             $signature = Get-AuthenticodeSignature $file
             if ($signature.Status -ne 'Valid') {
-              throw "Authenticode verification failed for $file: $($signature.StatusMessage)"
+              throw "Authenticode verification failed for ${file}: $($signature.StatusMessage)"
             }
           }
 

--- a/src/npx-launcher/package.json
+++ b/src/npx-launcher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tlbx-ai/midterm",
-  "version": "9.6.4",
+  "version": "9.6.5-dev",
   "description": "Launch MidTerm via npx by downloading the native binary for your platform",
   "license": "AGPL-3.0-only",
   "repository": {

--- a/src/version.json
+++ b/src/version.json
@@ -1,5 +1,5 @@
 {
-  "web": "9.6.4",
+  "web": "9.6.5-dev",
   "pty": "9.4.51",
   "protocol": 1,
   "minCompatiblePty": "2.0.0",


### PR DESCRIPTION
## Summary
Promoting `9.6.5-dev` to stable `9.6.5` - includes 1 dev releases since v9.6.4.

## Changelog

### v9.6.5-dev - Fix stable Windows signature verification script
- Fixed the stable Windows release workflow to use ${file} inside the Authenticode verification error message so PowerShell no longer parses the path variable incorrectly.
- Kept the Windows signing and verification steps intact while removing the parser error that broke the stable build-windows job after successful signing.
- Restored the stable release path after v9.6.4 failed only in the final Windows signature verification step, while v9.6.4-dev itself remained green.

