### PR TITLE
Align app chrome and dev browser sizing

### DIFF
--- a/src/Ai.Tlbx.MidTerm/src/static/css/app.css
+++ b/src/Ai.Tlbx.MidTerm/src/static/css/app.css
@@ -312,6 +312,7 @@
   --bg-input: #242735; /* Alias for compatibility */
   --bg-dropdown: #242735; /* Alias for compatibility */
   --bg-elevated-opaque: #161821; /* Opaque modal/card shell */
+  --bg-sidebar-opaque: #05050a; /* Opaque sidebar/header shell */
   --bg-dropdown-opaque: #242735; /* Opaque dropdown/menu shell */
   --bg-session-hover-opaque: #1c1e2a; /* Sidebar item hover shell */
   --bg-session-active-opaque: #1c1e2a; /* Sidebar item active shell */
@@ -327,6 +328,12 @@
   --terminal-canvas-background: var(--bg-terminal);
   --terminal-ui-background: var(--terminal-bg);
   --app-chrome-background: var(--bg-terminal);
+  --app-header-background:
+    linear-gradient(
+      var(--app-chrome-background, var(--bg-terminal)),
+      var(--app-chrome-background, var(--bg-terminal))
+    ),
+    var(--bg-sidebar-opaque, var(--bg-sidebar));
   --workspace-pane-background: var(--bg-primary);
   --workspace-pane-chrome-background: var(--bg-elevated);
   --text-input-background: var(--bg-input);
@@ -722,7 +729,7 @@ body::before {
   box-sizing: border-box;
   border-bottom: 2px solid transparent;
   border-image: linear-gradient(90deg, transparent, var(--accent-gold-40), transparent) 1;
-  background-color: var(--app-chrome-background, var(--bg-terminal));
+  background: var(--app-header-background);
   position: relative;
 }
 
@@ -2912,7 +2919,7 @@ body.has-app-background:not(.opaque-terminal-surfaces) .spaces-tree-adhoc-list {
 
 .layout-leaf .session-tab-bar {
   border-bottom: 1px solid color-mix(in srgb, var(--text-primary) 6%, transparent);
-  background-color: var(--app-chrome-background, var(--bg-terminal));
+  background: var(--app-header-background);
   padding: 0 4px;
 }
 
@@ -2952,7 +2959,7 @@ body.has-app-background:not(.opaque-terminal-surfaces) .spaces-tree-adhoc-list {
 
 .layout-leaf.focused .session-tab-bar {
   border-bottom-color: color-mix(in srgb, var(--accent-gold) 16%, transparent);
-  background-color: var(--app-chrome-background, var(--bg-terminal));
+  background: var(--app-header-background);
 }
 
 /* Dock overlay - shown during drag to indicate drop zones */
@@ -10433,6 +10440,7 @@ body.shared-session-mode .session-tab-bar {
   right: 0;
   bottom: 0;
   width: 400px;
+  max-width: 80%;
   background: var(--workspace-pane-background);
   border-left: 1px solid var(--border-color);
   display: flex;
@@ -11417,7 +11425,7 @@ body.opaque-terminal-surfaces .session-wrapper[data-active-tab='agent'] {
   display: flex;
   align-items: center;
   gap: 0;
-  background-color: var(--app-chrome-background, var(--bg-terminal));
+  background: var(--app-header-background);
   border-bottom: none;
   flex-shrink: 0;
   padding: 0 8px;

--- a/src/Ai.Tlbx.MidTerm/src/static/css/app.css
+++ b/src/Ai.Tlbx.MidTerm/src/static/css/app.css
@@ -517,7 +517,7 @@
   --transition-fast: 0.1s;
   --transition-normal: 0.15s;
   --transition-slow: 0.3s;
-  --smart-input-control-height: 40px;
+  --smart-input-control-height: 42px;
   --adaptive-footer-reserved-height: 0px;
 
   --app-background-image: none;
@@ -2912,7 +2912,7 @@ body.has-app-background:not(.opaque-terminal-surfaces) .spaces-tree-adhoc-list {
 
 .layout-leaf .session-tab-bar {
   border-bottom: 1px solid color-mix(in srgb, var(--text-primary) 6%, transparent);
-  background: var(--app-chrome-background, var(--bg-terminal));
+  background-color: var(--app-chrome-background, var(--bg-terminal));
   padding: 0 4px;
 }
 
@@ -2952,7 +2952,7 @@ body.has-app-background:not(.opaque-terminal-surfaces) .spaces-tree-adhoc-list {
 
 .layout-leaf.focused .session-tab-bar {
   border-bottom-color: color-mix(in srgb, var(--accent-gold) 16%, transparent);
-  background: var(--app-chrome-background, var(--bg-terminal));
+  background-color: var(--app-chrome-background, var(--bg-terminal));
 }
 
 /* Dock overlay - shown during drag to indicate drop zones */
@@ -11417,7 +11417,7 @@ body.opaque-terminal-surfaces .session-wrapper[data-active-tab='agent'] {
   display: flex;
   align-items: center;
   gap: 0;
-  background: var(--app-chrome-background, var(--bg-terminal));
+  background-color: var(--app-chrome-background, var(--bg-terminal));
   border-bottom: none;
   flex-shrink: 0;
   padding: 0 8px;
@@ -15832,7 +15832,7 @@ body.has-app-background:not(.opaque-terminal-surfaces)
 
 .adaptive-footer-dock {
   --command-bay-gap: 6px;
-  --command-bay-control-height: 34px;
+  --command-bay-control-height: 36px;
   --command-bay-control-height-mobile: 44px;
   --command-bay-automation-chip-height: calc(var(--command-bay-control-height) * 0.85);
   --command-bay-automation-chip-font-size: calc(var(--command-bay-font-size) - 1pt);
@@ -15931,8 +15931,6 @@ body.has-app-background:not(.opaque-terminal-surfaces)
     color-mix(in srgb, var(--terminal-ui-background, var(--terminal-bg)) 74%, transparent) 28%,
     color-mix(in srgb, var(--terminal-ui-background, var(--terminal-bg)) 90%, transparent)
   );
-  -webkit-backdrop-filter: blur(12.6px) saturate(112%);
-  backdrop-filter: blur(12.6px) saturate(112%);
 }
 
 .adaptive-footer-dock[data-composer-expanded='true'] {

--- a/src/Ai.Tlbx.MidTerm/src/ts/modules/smartInput/smartInput.wiring.test.ts
+++ b/src/Ai.Tlbx.MidTerm/src/ts/modules/smartInput/smartInput.wiring.test.ts
@@ -20,6 +20,16 @@ const lensResumeButtonSource = readFileSync(path.join(__dirname, 'lensResumeButt
 const css = readFileSync(path.join(__dirname, '../../../static/css/app.css'), 'utf8');
 const html = readFileSync(path.join(__dirname, '../../../static/index.html'), 'utf8');
 
+function getCssRule(selector: string): string {
+  const start = css.indexOf(`${selector} {`);
+  if (start < 0) {
+    return '';
+  }
+
+  const end = css.indexOf('\n}', start);
+  return end >= 0 ? css.slice(start, end + 2) : '';
+}
+
 describe('smart input tab wiring', () => {
   it('resyncs smart input visibility when non-Lens tabs activate', () => {
     expect(source).toContain("onTabActivated('agent', (sessionId) => {");
@@ -46,6 +56,14 @@ describe('smart input tab wiring', () => {
     expect(source).not.toContain(
       'const transparency = settings?.terminalTransparency ?? settings?.uiTransparency ?? 0;',
     );
+  });
+
+  it('keeps the Command Bay material unfrosted', () => {
+    const glassRule = getCssRule(".adaptive-footer-dock[data-material='glass']");
+
+    expect(glassRule).toContain("adaptive-footer-dock[data-material='glass']");
+    expect(glassRule).not.toContain('backdrop-filter');
+    expect(glassRule).not.toContain('-webkit-backdrop-filter');
   });
 
   it('keeps Lens quick settings hidden when the hidden attribute is set', () => {
@@ -166,7 +184,8 @@ describe('smart input tab wiring', () => {
     expect(css).toContain(".adaptive-footer-status[data-lens-compact='true'] {");
     expect(css).toContain('position: relative;');
     expect(css).toContain('z-index: 3;');
-    expect(css).toContain('--command-bay-control-height: 34px;');
+    expect(css).toContain('--smart-input-control-height: 42px;');
+    expect(css).toContain('--command-bay-control-height: 36px;');
     expect(css).toContain('--command-bay-surface: color-mix(');
     expect(css).toContain('align-items: center;');
     expect(css).toContain('.smart-input-tools-toggle::before,');

--- a/src/Ai.Tlbx.MidTerm/src/ts/modules/theming/workspacePaneTransparency.wiring.test.ts
+++ b/src/Ai.Tlbx.MidTerm/src/ts/modules/theming/workspacePaneTransparency.wiring.test.ts
@@ -53,16 +53,24 @@ describe('workspace pane transparency wiring', () => {
     const focusedLayoutLeafSessionTabBarRule = getCssRule('.layout-leaf.focused .session-tab-bar');
 
     expect(css).toContain('--app-chrome-background: var(--bg-terminal);');
+    expect(css).toContain('--app-header-background:');
+    expect(css).toContain('var(--bg-sidebar-opaque, var(--bg-sidebar));');
     expect(sidebarHeaderRule).toContain(
-      'background-color: var(--app-chrome-background, var(--bg-terminal));',
+      'background: var(--app-header-background);',
     );
     expect(sessionTabBarRule).toContain(
-      'background-color: var(--app-chrome-background, var(--bg-terminal));',
+      'background: var(--app-header-background);',
     );
     expect(layoutLeafSessionTabBarRule).toContain(
-      'background-color: var(--app-chrome-background, var(--bg-terminal));',
+      'background: var(--app-header-background);',
     );
     expect(focusedLayoutLeafSessionTabBarRule).toContain(
+      'background: var(--app-header-background);',
+    );
+    expect(sidebarHeaderRule).not.toContain(
+      'background-color: var(--app-chrome-background, var(--bg-terminal));',
+    );
+    expect(sessionTabBarRule).not.toContain(
       'background-color: var(--app-chrome-background, var(--bg-terminal));',
     );
     expect(sessionTabBarRule).not.toContain(

--- a/src/Ai.Tlbx.MidTerm/src/ts/modules/theming/workspacePaneTransparency.wiring.test.ts
+++ b/src/Ai.Tlbx.MidTerm/src/ts/modules/theming/workspacePaneTransparency.wiring.test.ts
@@ -7,6 +7,16 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const css = readFileSync(path.join(__dirname, '../../../static/css/app.css'), 'utf8');
 
+function getCssRule(selector: string): string {
+  const start = css.indexOf(`${selector} {`);
+  if (start < 0) {
+    return '';
+  }
+
+  const end = css.indexOf('\n}', start);
+  return end >= 0 ? css.slice(start, end + 2) : '';
+}
+
 describe('workspace pane transparency wiring', () => {
   it('keeps files, git, and web panes out of terminal-scoped background tokens', () => {
     expect(css).toContain('--workspace-pane-background: var(--bg-primary);');
@@ -36,12 +46,34 @@ describe('workspace pane transparency wiring', () => {
     expect(css).toContain('background: var(--terminal-canvas-background, var(--terminal-bg));');
   });
 
-  it('binds the sidebar header and IDE bar to the shared app chrome background', () => {
+  it('binds the sidebar header and terminal header to the same app chrome background style', () => {
+    const sidebarHeaderRule = getCssRule('.sidebar-header');
+    const sessionTabBarRule = getCssRule('.session-tab-bar');
+    const layoutLeafSessionTabBarRule = getCssRule('.layout-leaf .session-tab-bar');
+    const focusedLayoutLeafSessionTabBarRule = getCssRule('.layout-leaf.focused .session-tab-bar');
+
     expect(css).toContain('--app-chrome-background: var(--bg-terminal);');
-    expect(css).toContain(
+    expect(sidebarHeaderRule).toContain(
       'background-color: var(--app-chrome-background, var(--bg-terminal));',
     );
-    expect(css).toContain('background: var(--app-chrome-background, var(--bg-terminal));');
+    expect(sessionTabBarRule).toContain(
+      'background-color: var(--app-chrome-background, var(--bg-terminal));',
+    );
+    expect(layoutLeafSessionTabBarRule).toContain(
+      'background-color: var(--app-chrome-background, var(--bg-terminal));',
+    );
+    expect(focusedLayoutLeafSessionTabBarRule).toContain(
+      'background-color: var(--app-chrome-background, var(--bg-terminal));',
+    );
+    expect(sessionTabBarRule).not.toContain(
+      'background: var(--app-chrome-background, var(--bg-terminal));',
+    );
+    expect(layoutLeafSessionTabBarRule).not.toContain(
+      'background: var(--app-chrome-background, var(--bg-terminal));',
+    );
+    expect(focusedLayoutLeafSessionTabBarRule).not.toContain(
+      'background: var(--app-chrome-background, var(--bg-terminal));',
+    );
     expect(css).not.toContain('color-mix(in srgb, var(--bg-dialog-chrome) 94%, transparent)');
   });
 });

--- a/src/Ai.Tlbx.MidTerm/src/ts/modules/web/webDock.ts
+++ b/src/Ai.Tlbx.MidTerm/src/ts/modules/web/webDock.ts
@@ -24,8 +24,17 @@ import { isEmbeddedWebPreviewContext } from './webContext';
 const log = createLogger('webDock');
 
 const DOCK_MIN_WIDTH = 250;
-const DOCK_MAX_WIDTH = 800;
+const DOCK_MAX_WIDTH_RATIO = 0.8;
 const DOCK_WIDTH_KEY = 'mt-web-preview-dock-width';
+
+function getDockMaxWidth(panel: HTMLElement): number {
+  const availableWidth = panel.parentElement?.clientWidth ?? window.innerWidth;
+  return Math.max(DOCK_MIN_WIDTH, Math.floor(availableWidth * DOCK_MAX_WIDTH_RATIO));
+}
+
+function clampDockWidth(width: number, panel: HTMLElement): number {
+  return Math.max(DOCK_MIN_WIDTH, Math.min(getDockMaxWidth(panel), width));
+}
 
 function handleDockLayoutChange(): void {
   if ($isMainBrowser.get()) {
@@ -105,8 +114,8 @@ export function openWebPreviewDock(): void {
   const savedWidth = localStorage.getItem(DOCK_WIDTH_KEY);
   if (savedWidth) {
     const w = parseInt(savedWidth, 10);
-    if (w >= DOCK_MIN_WIDTH && w <= DOCK_MAX_WIDTH) {
-      dockPanel.style.width = `${w}px`;
+    if (w >= DOCK_MIN_WIDTH) {
+      dockPanel.style.width = `${clampDockWidth(w, dockPanel)}px`;
     }
   }
 
@@ -240,7 +249,7 @@ export function setupWebPreviewDockResize(): void {
   function updateResize(clientX: number): void {
     if (!isResizing) return;
     const delta = startX - clientX;
-    const newWidth = Math.max(DOCK_MIN_WIDTH, Math.min(DOCK_MAX_WIDTH, startWidth + delta));
+    const newWidth = clampDockWidth(startWidth + delta, panel);
     panel.style.width = `${newWidth}px`;
   }
 

--- a/src/Ai.Tlbx.MidTerm/src/ts/modules/web/webDock.wiring.test.ts
+++ b/src/Ai.Tlbx.MidTerm/src/ts/modules/web/webDock.wiring.test.ts
@@ -5,7 +5,9 @@ import { describe, expect, it } from 'vitest';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
+const projectRoot = path.resolve(__dirname, '../../../..');
 const source = readFileSync(path.join(__dirname, 'webDock.ts'), 'utf8');
+const css = readFileSync(path.join(projectRoot, 'src/static/css/app.css'), 'utf8');
 
 describe('web dock footer spacing wiring', () => {
   it('pushes the adaptive footer dock left when right-side docks are visible', () => {
@@ -13,5 +15,17 @@ describe('web dock footer spacing wiring', () => {
     expect(source).toContain("footerDock.style.right = total > 0 ? `${total}px` : '';");
     expect(source).toContain("const managerQueue = document.getElementById('manager-bar-queue');");
     expect(source).toContain("managerQueue.style.marginRight = total > 0 ? `${total}px` : '';");
+  });
+
+  it('limits the docked dev browser to 80 percent of the available horizontal space', () => {
+    expect(css).toContain('.web-preview-dock {');
+    expect(css).toContain('max-width: 80%;');
+    expect(source).toContain('const DOCK_MAX_WIDTH_RATIO = 0.8;');
+    expect(source).toContain('function getDockMaxWidth(panel: HTMLElement): number {');
+    expect(source).toContain('panel.parentElement?.clientWidth ?? window.innerWidth');
+    expect(source).toContain('Math.floor(availableWidth * DOCK_MAX_WIDTH_RATIO)');
+    expect(source).toContain('dockPanel.style.width = `${clampDockWidth(w, dockPanel)}px`;');
+    expect(source).toContain('const newWidth = clampDockWidth(startWidth + delta, panel);');
+    expect(source).not.toContain('const DOCK_MAX_WIDTH = 800;');
   });
 });

--- a/src/npx-launcher/package.json
+++ b/src/npx-launcher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tlbx-ai/midterm",
-  "version": "9.8.1-dev",
+  "version": "9.8.2-dev",
   "description": "Launch MidTerm via npx by downloading the native binary for your platform",
   "license": "AGPL-3.0-only",
   "repository": {

--- a/src/npx-launcher/package.json
+++ b/src/npx-launcher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tlbx-ai/midterm",
-  "version": "9.8.0",
+  "version": "9.8.1-dev",
   "description": "Launch MidTerm via npx by downloading the native binary for your platform",
   "license": "AGPL-3.0-only",
   "repository": {

--- a/src/version.json
+++ b/src/version.json
@@ -1,5 +1,5 @@
 {
-  "web": "9.8.0",
+  "web": "9.8.1-dev",
   "pty": "9.7.5",
   "protocol": 1,
   "minCompatiblePty": "2.0.0",

--- a/src/version.json
+++ b/src/version.json
@@ -1,5 +1,5 @@
 {
-  "web": "9.8.1-dev",
+  "web": "9.8.2-dev",
   "pty": "9.7.5",
   "protocol": 1,
   "minCompatiblePty": "2.0.0",


### PR DESCRIPTION
## Summary
Promoting `9.8.2-dev` to stable `9.8.2` - includes 2 dev releases since v9.8.0.

## Changelog

### v9.8.1-dev - Refine Command Bay and terminal header styling
- Made the Command Bay 2px taller by raising its composer and control heights.
- Removed the frosted glass backdrop filter behind the Command Bay while preserving its material gradient.
- Matched the terminal IDE bar background style to the sidebar header so both use the same app chrome background color and transparency behavior.

### v9.8.2-dev - Align app chrome and dev browser sizing
- Made the sidebar header and terminal IDE bar use the same layered app header background so UI transparency affects both consistently.
- Limited the docked dev browser to 80 percent of the available horizontal space, including restored saved widths and live resize dragging.
- Added wiring coverage for the shared header background and dev browser width clamp.

