### PR TITLE
Stabilize release log rotation test

### DIFF
--- a/src/Ai.Tlbx.MidTerm.UnitTests/LogWriterTests.cs
+++ b/src/Ai.Tlbx.MidTerm.UnitTests/LogWriterTests.cs
@@ -12,19 +12,14 @@ public sealed class LogWriterTests : IDisposable
     {
         Directory.CreateDirectory(_tempDirectory);
 
+        using (var logger = CreateLogger())
         {
-            using var logger = new Logger("mt", _tempDirectory, new LogRotationPolicy
-            {
-                MaxFileSizeBytes = 80,
-                MaxFileCount = 10,
-                MaxDirectorySizeBytes = 1024 * 1024
-            });
-
-            logger.MinLevel = LogSeverity.Info;
             logger.Info(() => new string('A', 60));
-            Thread.Sleep(250);
+        }
+
+        using (var logger = CreateLogger())
+        {
             logger.Info(() => new string('B', 60));
-            Thread.Sleep(250);
         }
 
         var logFiles = Directory.GetFiles(_tempDirectory, "mt-*.log")
@@ -36,6 +31,18 @@ public sealed class LogWriterTests : IDisposable
         Assert.EndsWith(".001.log", logFiles[1], StringComparison.OrdinalIgnoreCase);
         Assert.Contains("AAAA", File.ReadAllText(logFiles[0]), StringComparison.Ordinal);
         Assert.Contains("BBBB", File.ReadAllText(logFiles[1]), StringComparison.Ordinal);
+    }
+
+    private Logger CreateLogger()
+    {
+        var logger = new Logger("mt", _tempDirectory, new LogRotationPolicy
+        {
+            MaxFileSizeBytes = 80,
+            MaxFileCount = 10,
+            MaxDirectorySizeBytes = 1024 * 1024
+        });
+        logger.MinLevel = LogSeverity.Info;
+        return logger;
     }
 
     public void Dispose()

--- a/src/npx-launcher/package.json
+++ b/src/npx-launcher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tlbx-ai/midterm",
-  "version": "9.9.0",
+  "version": "9.9.1-dev",
   "description": "Launch MidTerm via npx by downloading the native binary for your platform",
   "license": "AGPL-3.0-only",
   "repository": {

--- a/src/version.json
+++ b/src/version.json
@@ -1,6 +1,7 @@
 {
-  "web": "9.9.0",
+  "web": "9.9.1-dev",
   "pty": "9.9.0",
   "protocol": 1,
-  "minCompatiblePty": "2.0.0"
+  "minCompatiblePty": "2.0.0",
+  "webOnly": true
 }


### PR DESCRIPTION
## Summary
Promoting `9.9.1-dev` to stable `9.9.1` - includes 1 dev releases since v9.9.0.

## Changelog

### v9.9.1-dev - Stabilize release log rotation test
- Hardened the log rotation test so CI does not depend on background writer scheduling between queued log entries.

