### PR TITLE
Keep Dev Browser panes readable with UI transparency

### DIFF
--- a/src/Ai.Tlbx.MidTerm/src/static/css/app.css
+++ b/src/Ai.Tlbx.MidTerm/src/static/css/app.css
@@ -10433,7 +10433,7 @@ body.shared-session-mode .session-tab-bar {
   bottom: 0;
   width: 400px;
   max-width: 80%;
-  background: var(--workspace-pane-background);
+  background: var(--web-preview-pane-background, var(--workspace-pane-background));
   border-left: 1px solid var(--border-color);
   display: flex;
   flex-direction: column;
@@ -10466,7 +10466,7 @@ body.shared-session-mode .session-tab-bar {
   height: var(--bar-height);
   box-sizing: border-box;
   border-bottom: 1px solid var(--border-color);
-  background: var(--workspace-pane-chrome-background);
+  background: var(--web-preview-pane-chrome-background, var(--workspace-pane-chrome-background));
   gap: 8px;
 }
 
@@ -10505,8 +10505,8 @@ body.shared-session-mode .session-tab-bar {
   border-bottom: 1px solid var(--border-color);
   background: linear-gradient(
     180deg,
-    var(--workspace-pane-chrome-background),
-    var(--workspace-pane-background)
+    var(--web-preview-pane-chrome-background, var(--workspace-pane-chrome-background)),
+    var(--web-preview-pane-background, var(--workspace-pane-background))
   );
   overflow-x: auto;
   scrollbar-width: none;
@@ -10519,7 +10519,11 @@ body.shared-session-mode .session-tab-bar {
 .web-preview-tab-shell {
   border: 1px solid var(--border-color);
   border-bottom-color: transparent;
-  background: color-mix(in srgb, var(--bg-surface) 86%, transparent);
+  background: color-mix(
+    in srgb,
+    var(--web-preview-pane-surface-background, var(--bg-surface)) 86%,
+    transparent
+  );
   color: var(--text-secondary);
   border-radius: 8px 8px 0 0;
   display: inline-flex;
@@ -10542,11 +10546,15 @@ body.shared-session-mode .session-tab-bar {
 
 .web-preview-tab-shell.active {
   border-color: var(--accent-gold);
-  border-bottom-color: var(--workspace-pane-background);
+  border-bottom-color: var(--web-preview-pane-background, var(--workspace-pane-background));
   background: linear-gradient(
     180deg,
-    var(--workspace-pane-chrome-background),
-    color-mix(in srgb, var(--accent-gold-10) 55%, var(--workspace-pane-background))
+    var(--web-preview-pane-chrome-background, var(--workspace-pane-chrome-background)),
+    color-mix(
+      in srgb,
+      var(--accent-gold-10) 55%,
+      var(--web-preview-pane-background, var(--workspace-pane-background))
+    )
   );
   color: var(--text-primary);
   box-shadow: inset 0 0 0 1px var(--accent-gold-25);
@@ -10605,7 +10613,7 @@ body.shared-session-mode .session-tab-bar {
   padding: 6px 8px;
   gap: 4px;
   border-bottom: 1px solid var(--border-color);
-  background: var(--workspace-pane-chrome-background);
+  background: var(--web-preview-pane-chrome-background, var(--workspace-pane-chrome-background));
 }
 
 .web-preview-dock-url-bar input {
@@ -10645,7 +10653,11 @@ body.shared-session-mode .session-tab-bar {
 .web-preview-action-message {
   padding: 7px 10px;
   border-bottom: 1px solid var(--border-color);
-  background: color-mix(in srgb, var(--workspace-pane-chrome-background) 92%, transparent);
+  background: color-mix(
+    in srgb,
+    var(--web-preview-pane-chrome-background, var(--workspace-pane-chrome-background)) 92%,
+    transparent
+  );
   color: var(--text-secondary);
   font-size: var(--fs-sm);
   line-height: 1.35;
@@ -10659,7 +10671,7 @@ body.shared-session-mode .session-tab-bar {
   background: color-mix(
     in srgb,
     var(--accent-red) 12%,
-    var(--workspace-pane-chrome-background) 88%
+    var(--web-preview-pane-chrome-background, var(--workspace-pane-chrome-background)) 88%
   );
   color: color-mix(in srgb, var(--accent-red) 68%, var(--text-primary) 32%);
   border-bottom-color: color-mix(in srgb, var(--accent-red) 28%, var(--border-color) 72%);
@@ -10669,7 +10681,7 @@ body.shared-session-mode .session-tab-bar {
   background: color-mix(
     in srgb,
     var(--accent-blue-10) 55%,
-    var(--workspace-pane-chrome-background) 45%
+    var(--web-preview-pane-chrome-background, var(--workspace-pane-chrome-background)) 45%
   );
   color: var(--text-primary);
   border-bottom-color: color-mix(in srgb, var(--accent-blue-25) 55%, var(--border-color) 45%);
@@ -10708,7 +10720,11 @@ body.shared-session-mode .session-tab-bar {
   height: 28px;
   border-radius: 999px;
   border: 1px solid var(--border-color);
-  background: color-mix(in srgb, var(--workspace-pane-chrome-background) 90%, transparent);
+  background: color-mix(
+    in srgb,
+    var(--web-preview-pane-chrome-background, var(--workspace-pane-chrome-background)) 90%,
+    transparent
+  );
   color: var(--text-secondary);
   font-size: 15px;
   font-weight: 700;
@@ -10731,7 +10747,7 @@ body.shared-session-mode .session-tab-bar {
   background: color-mix(
     in srgb,
     var(--accent-blue-10) 62%,
-    var(--workspace-pane-chrome-background) 38%
+    var(--web-preview-pane-chrome-background, var(--workspace-pane-chrome-background)) 38%
   );
   color: var(--accent-blue-hover);
 }
@@ -10741,7 +10757,7 @@ body.shared-session-mode .session-tab-bar {
   background: color-mix(
     in srgb,
     var(--accent-gold-10) 62%,
-    var(--workspace-pane-chrome-background) 38%
+    var(--web-preview-pane-chrome-background, var(--workspace-pane-chrome-background)) 38%
   );
   color: var(--accent-gold);
 }
@@ -10751,7 +10767,7 @@ body.shared-session-mode .session-tab-bar {
   background: color-mix(
     in srgb,
     var(--accent-red) 14%,
-    var(--workspace-pane-chrome-background) 86%
+    var(--web-preview-pane-chrome-background, var(--workspace-pane-chrome-background)) 86%
   );
   color: color-mix(in srgb, var(--accent-red) 58%, var(--text-primary) 42%);
 }
@@ -10760,14 +10776,14 @@ body.shared-session-mode .session-tab-bar {
   flex: 1;
   overflow: hidden;
   position: relative;
-  background: var(--workspace-pane-background);
+  background: var(--web-preview-pane-background, var(--workspace-pane-background));
 }
 
 .web-preview-dock-body.viewport-constrained {
   display: flex;
   align-items: center;
   justify-content: center;
-  background: var(--workspace-pane-background);
+  background: var(--web-preview-pane-background, var(--workspace-pane-background));
 }
 
 #web-preview-iframe-host {

--- a/src/Ai.Tlbx.MidTerm/src/ts/modules/theming/backgroundAppearance.test.ts
+++ b/src/Ai.Tlbx.MidTerm/src/ts/modules/theming/backgroundAppearance.test.ts
@@ -205,6 +205,25 @@ describe('backgroundAppearance', () => {
     expect(alphaOf(rootStyle.getPropertyValue('--app-chrome-background'))).toBeCloseTo(0.75, 5);
   });
 
+  it('keeps Dev Browser panes 85 percent opaque at full UI transparency', () => {
+    applyBackgroundAppearance(
+      createSettings({
+        theme: 'dark',
+        uiTransparency: 100,
+      }),
+    );
+
+    expect(alphaOf(rootStyle.getPropertyValue('--web-preview-pane-background'))).toBeCloseTo(0.85, 5);
+    expect(alphaOf(rootStyle.getPropertyValue('--web-preview-pane-chrome-background'))).toBeCloseTo(
+      0.85,
+      5,
+    );
+    expect(alphaOf(rootStyle.getPropertyValue('--web-preview-pane-surface-background'))).toBeCloseTo(
+      0.85,
+      5,
+    );
+  });
+
   it('uses the selected terminal color scheme for the terminal canvas background', () => {
     applyBackgroundAppearance(
       createSettings({

--- a/src/Ai.Tlbx.MidTerm/src/ts/modules/theming/backgroundAppearance.ts
+++ b/src/Ai.Tlbx.MidTerm/src/ts/modules/theming/backgroundAppearance.ts
@@ -49,6 +49,19 @@ const DERIVED_BACKGROUND_VARIABLES: Array<{
   { name: '--terminal-canvas-background', source: '--bg-terminal', mode: 'terminal' },
   { name: '--terminal-ui-background', source: '--bg-terminal', mode: 'ui' },
   { name: '--app-chrome-background', source: '--bg-terminal', mode: 'ui', response: 0.25 },
+  { name: '--web-preview-pane-background', source: '--bg-primary', mode: 'ui', response: 0.15 },
+  {
+    name: '--web-preview-pane-chrome-background',
+    source: '--bg-elevated',
+    mode: 'ui',
+    response: 0.15,
+  },
+  {
+    name: '--web-preview-pane-surface-background',
+    source: '--bg-surface',
+    mode: 'ui',
+    response: 0.15,
+  },
   { name: '--text-input-background', source: '--bg-input', mode: 'ui', response: 0.2 },
   {
     name: '--sidebar-item-hover-background',

--- a/src/npx-launcher/package.json
+++ b/src/npx-launcher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tlbx-ai/midterm",
-  "version": "9.10.0",
+  "version": "9.10.1-dev",
   "description": "Launch MidTerm via npx by downloading the native binary for your platform",
   "license": "AGPL-3.0-only",
   "repository": {

--- a/src/version.json
+++ b/src/version.json
@@ -1,5 +1,5 @@
 {
-  "web": "9.10.0",
+  "web": "9.10.1-dev",
   "pty": "9.9.0",
   "protocol": 1,
   "minCompatiblePty": "2.0.0",


### PR DESCRIPTION
## Summary
Promoting `9.10.1-dev` to stable `9.10.1` - includes 1 dev releases since v9.10.0.

## Changelog

### v9.10.1-dev - Keep Dev Browser panes readable with UI transparency
- Make Dev Browser pane, chrome, tabs, URL bar, messages, and viewport backgrounds respond to only 15% of the UI transparency slider.
- At full UI transparency, Dev Browser pane surfaces remain 85% opaque for readability while the rest of the UI keeps its configured transparency.

