### PR TITLE
Point discovery surfaces at midterm.tlbx.ai

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 </p>
 
 <p align="center">
+  <a href="https://midterm.tlbx.ai"><strong>Website</strong></a>
+  ·
   <a href="#install"><strong>Install</strong></a>
   ·
   <a href="#agent-cli-ergonomics"><strong>Agent ergonomics</strong></a>
@@ -24,6 +26,8 @@ Start Grok Build, Codex, Claude Code, OpenCode, Antigravity CLI, Copilot CLI—o
 
 **Your machines are browser tabs. Your agents keep working when you leave.**
 
+Explore screenshots, architecture, features, and installation at **[midterm.tlbx.ai](https://midterm.tlbx.ai)**.
+
 <p align="center">
   <img src="docs/marketing/readme/browser-next-to-work.svg" alt="Codex, Claude Code, and Grok Build running concurrently on a home workstation controlled from a MidTerm browser tab beside another MidTerm host" width="100%">
 </p>
@@ -36,7 +40,6 @@ MidTerm runs any terminal-native tool in a real PTY, but it is shaped around lon
 - **Paste screenshots normally:** `Ctrl+V` / `Cmd+V` uploads the image to the host and inserts its path. Structured agent sessions stage it as an attachment.
 - **Compose real prompts:** multiline input, per-session drafts, files, drag-and-drop, camera capture, reusable actions, and scheduled follow-ups.
 - **Reuse exact inputs:** each session's **History** top-bar menu (`Alt+H` for the active session) keeps direct Enter-submitted text, multiline prompts, pastes, images, and files replayable in place.
-- **See what needs you:** Operator separates machine facts from agent-published status, todos, mail, coding tasks, next steps, and checkpoints across hosts.
 - **Let agents operate MidTerm:** generated `mt` helpers expose history, capabilities, direct multi-session dispatch, ordered events, and the control plane as stable JSON.
 - **Verify the result:** open the app beside the agent; inspect DOM, console/proxy logs, responsive layouts, and screenshots.
 - **Leave and return:** sessions survive browser disconnects, device changes, and travel.

--- a/docs/site/_includes/head-custom.html
+++ b/docs/site/_includes/head-custom.html
@@ -1,3 +1,9 @@
+{% if page.url == "/" %}
+<link rel="canonical" href="https://midterm.tlbx.ai/">
+<link rel="alternate" hreflang="en" href="https://midterm.tlbx.ai/">
+<link rel="alternate" hreflang="de" href="https://midterm.tlbx.ai/de">
+<link rel="alternate" hreflang="x-default" href="https://midterm.tlbx.ai/">
+{% endif %}
 <style>
 .code-copy-wrapper {
   position: relative;

--- a/docs/site/index.md
+++ b/docs/site/index.md
@@ -9,6 +9,8 @@ title: MidTerm
 
 Run Grok Build, Codex, Claude Code, OpenCode, Antigravity CLI, Copilot CLI—or all of them at once. MidTerm keeps their sessions alive and puts control in any browser.
 
+**Product website:** [midterm.tlbx.ai](https://midterm.tlbx.ai) — screenshots, architecture, features, and installation in English and German.
+
 - normal `Ctrl+V` / `Cmd+V` screenshot paste into terminal CLIs
 - multiline prompts, per-session drafts, files, camera input, and scheduled follow-ups
 - process, activity, repository, attention, approval, diff, and browser-proof surfaces
@@ -19,6 +21,7 @@ Install MidTerm:
 - macOS/Linux: `curl -fsSL https://tlbx-ai.github.io/MidTerm/install.sh | bash`
 - Windows: `irm https://tlbx-ai.github.io/MidTerm/install.ps1 | iex`
 - Source repo: [github.com/tlbx-ai/MidTerm](https://github.com/tlbx-ai/MidTerm)
+- Product website: [midterm.tlbx.ai](https://midterm.tlbx.ai)
 - Product docs: [docs/FEATURES.md](https://github.com/tlbx-ai/MidTerm/blob/main/docs/FEATURES.md)
 
 For private remote access, use Tailscale—or an equivalent WireGuard mesh VPN—and open MidTerm through the host's private address.


### PR DESCRIPTION
Points the public README and GitHub Pages index at the canonical MidTerm product site, adds canonical/hreflang metadata to the Pages root, and removes the shelved Operator claim from the README.

No runtime or installer changes.