### PR TITLE
Point npm metadata at midterm.tlbx.ai

### DIFF
--- a/src/npx-launcher/README.md
+++ b/src/npx-launcher/README.md
@@ -1,12 +1,14 @@
 # @tlbx-ai/midterm
 
-Launch MidTerm through `npx`.
+Ephemeral loopback launcher for [MidTerm](https://midterm.tlbx.ai), the browser control station for AI coding agents.
 
 ```bash
 npx @tlbx-ai/midterm
 ```
 
 The launcher downloads the native MidTerm release for your platform, caches it in your user profile, runs it locally, and opens MidTerm in your default browser.
+
+For persistent or remote operation, use the [native installer](https://midterm.tlbx.ai/install). The npm launcher is the quick-trial fallback.
 
 Supported platforms:
 

--- a/src/npx-launcher/package.json
+++ b/src/npx-launcher/package.json
@@ -7,7 +7,7 @@
     "type": "git",
     "url": "git+https://github.com/tlbx-ai/MidTerm.git"
   },
-  "homepage": "https://github.com/tlbx-ai/MidTerm",
+  "homepage": "https://midterm.tlbx.ai",
   "bugs": {
     "url": "https://github.com/tlbx-ai/MidTerm/issues"
   },


### PR DESCRIPTION
Sets the npm launcher homepage to the canonical product site and makes the package README explicit that npx is the ephemeral fallback behind the native installer.