### PR TITLE
Respect the Action Graphs opt-in

### DIFF
--- a/src/Ai.Tlbx.MidTerm/src/static/css/app.css
+++ b/src/Ai.Tlbx.MidTerm/src/static/css/app.css
@@ -4834,6 +4834,10 @@ body::before {
   overflow: visible;
 }
 
+.sidebar-nav-btn.hidden {
+  display: none;
+}
+
 .sidebar-nav-btn:hover {
   background-color: var(--bg-session-hover);
   color: var(--text-primary);

--- a/src/Ai.Tlbx.MidTerm/src/ts/modules/actionGraphs/availability.test.ts
+++ b/src/Ai.Tlbx.MidTerm/src/ts/modules/actionGraphs/availability.test.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from 'node:fs';
 import { describe, expect, it } from 'vitest';
 
 import { isActionGraphsAvailable } from './availability';
@@ -8,5 +9,13 @@ describe('Action Graph availability', () => {
     expect(isActionGraphsAvailable({ actionGraphsEnabled: false })).toBe(false);
     expect(isActionGraphsAvailable({ actionGraphsEnabled: false, devMode: true })).toBe(false);
     expect(isActionGraphsAvailable({ actionGraphsEnabled: true, devMode: false })).toBe(true);
+  });
+
+  it('keeps the opt-in sidebar entry hidden until availability enables it', () => {
+    const html = readFileSync(new URL('../../../static/index.html', import.meta.url), 'utf8');
+    const css = readFileSync(new URL('../../../static/css/app.css', import.meta.url), 'utf8');
+
+    expect(html).toContain('class="sidebar-nav-btn btn-action-graphs hidden"');
+    expect(css).toMatch(/\.sidebar-nav-btn\.hidden\s*\{\s*display:\s*none;\s*\}/);
   });
 });

--- a/src/npx-launcher/package.json
+++ b/src/npx-launcher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tlbx-ai/midterm",
-  "version": "10.6.2",
+  "version": "10.6.3-dev",
   "description": "Quick-trial launcher for tlbx, the self-hosted browser control station for remote AI coding agents",
   "license": "AGPL-3.0-only",
   "repository": {

--- a/src/version.json
+++ b/src/version.json
@@ -1,5 +1,5 @@
 {
-  "web": "10.6.2",
+  "web": "10.6.3-dev",
   "pty": "10.3.1",
   "protocol": 1,
   "minCompatiblePty": "2.0.0",


### PR DESCRIPTION
## Summary
Promoting `10.6.3-dev` to stable `10.6.3` - includes 1 dev releases since v10.6.2.

## Changelog

### v10.6.3-dev - Respect the Action Graphs opt-in
- Hide the Action Graphs sidebar entry while the setting is disabled
- Keep developer mode from exposing the unfinished Action Graphs surface
- Add a regression test for the sidebar hidden-style contract

